### PR TITLE
Refocus activity on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 git-activity
 ============
 
-A pre-POSSE activity to become familiar with Git and GitHub.
+A pre-POSSE activity to become familiar with GitHub.
 
 Instructions
 ============
 
-1. Complete http://try.github.com.
 1. Log into GitHub.
 2. Fork [this repository](https://github.com/foss2serve/git-activity).
 3. In your forked copy, add your information to rollcall.md.


### PR DESCRIPTION
The POSSE activity that points here [1] now asks participants to download, install, and configure git.
This activities purpose is now to help participants to interact with GitHub.
The Stage 2 activities will have participants use Git and GitHub more thoroughly.

Changes:
* Remove instruction to complete try-git.
* Remove goal of "become familiar with Git". Now it's just GitHub.


[1] http://foss2serve.org/index.php/Intro_to_GitHub_(Activity)